### PR TITLE
Draft of handling names like SimpleHTTPServer

### DIFF
--- a/camel-spell.el
+++ b/camel-spell.el
@@ -97,6 +97,15 @@ position of the STR exclusive."
   (let ((case-fold-search nil))
     (setq str (replace-regexp-in-string
                "\\([a-z0-9]\\)\\([A-Z]\\)" "\\1 \\2" str))
+
+    ;; Handle NamesWithABBREVIATIONSInThem
+    (setq str (replace-regexp-in-string
+               "\\([A-Z]+\\)\\([A-Z][a-z0-9]\\)" "\\1 \\2" str))
+
+    ;; Handle NamesEndingInABBREVIATIONS.
+    (setq str (replace-regexp-in-string
+               "\\([a-z0-9]\\)\\([A-Z]\\'\\)" "\\1 \\2" str))
+
     (split-string str)))
 
 (defun camel-spell-break-camel-case-results (word-info)
@@ -118,10 +127,10 @@ one word info."
   "Advises `ispell-get-word' to correctly spell check camel cased words."
   (if (camel-spell-sub-word-list-has-entries-p)
       (camel-spell-pop-sub-word-list)
-    
+
     (let* ((word-info (apply orig-ispell-get-words args))
            (camel-infos (camel-spell-break-camel-case-results word-info)))
-      
+
       (setq camel-spell-sub-word-list
             (append camel-spell-sub-word-list (cdr-safe camel-infos)))
       (car camel-infos))))

--- a/test/camel-spell-test.el
+++ b/test/camel-spell-test.el
@@ -14,14 +14,15 @@
 (ert-deftest camel-spell-test/break-string ()
   "Test `camel-spell-break-string'."
   (cl-loop for (input expected) in
-           '(("" "")
-             ("a" "a")
-             ("abc" "abc")
-             ("aB" '("a" "B"))
-             ("aBB" '("a" "BB"))
-             ("fooBarBaz" '("foo" "Bar" "Baz"))
-             ("fooBarHTML" '("foo" "Bar" "HTML"))
-             ("FOObarBaz" '("FOO" "bar" "Baz")))
+           '(("" nil)
+             ("a" ("a"))
+             ("abc" ("abc"))
+             ("aB" ("a" "B"))
+             ("aBB" ("a" "BB"))
+             ("fooBarBaz" ("foo" "Bar" "Baz"))
+             ("fooHTMLBaz" ("foo" "HTML" "Baz"))
+             ("fooBarHTML" ("foo" "Bar" "HTML"))
+             ("FOObarBaz" ("FOO" "bar" "Baz")))
            do
            (should (equal (camel-spell-break-string input) expected))))
 


### PR DESCRIPTION
When I stumbled across this package yesterday, I immediately tried integrating it into my config, as spell-checking camelCaseNames has been a sore spot for me for quite a long time.

I noticed quickly that it didn't handle names the way they're usually written in Python code, with abbreviations capitalized and the following word with an initial capital letter, such as the `SimpleHTTPServer` from Python's standard library.

As I discovered when I started on this PR this evening, the current test suite suggests the library's designed to handle names in a different format, one not compatible with the Python approach - see the one test that's currently failing in my branch.

What I have isn't ready to be merged, since the test suite contains mutually-incompatible tests, but I thought it was worth throwing a PR out there for discussion.

Do you have any interest in the approach I have here, where the last capital letter is treated as part of the next word?

I guess both behaviors could be implemented and users could pick one by toggling a variable. That might just be needless complexity, though.

Thanks for the package! It's a big improvement on what I had before.